### PR TITLE
changelog input

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -8,12 +8,12 @@ layout: default
 permalink: /standards-guidelines/changelog/
 ref: /standards-guidelines/changelog/
 github:
-   repository: w3c/wai-std-gl-overview
-   path: content/changelog.md
+ repository: w3c/wai-std-gl-overview
+ path: content/changelog.md
 
 feedbackmail: wai@w3.org
 footer: >
-   <p>Thanks to Tolu Adegbite for updating this changelog in May 2021.</p>
+ <p>Thanks to Tolu Adegbite for updating this changelog.</p>
 ---
 
 {::nomarkdown}
@@ -29,47 +29,50 @@ footer: >
 {:/}
 
 
+## May 2021
+* In the frontmatter at the top, add ```changelog: /videos/standards-and-benefits/changelog/``` between ref and layout:<br>
+```
+ref: /videos/standards-and-benefits/   # Do not change this
+changelog: /videos/standards-and-benefits/changelog/
+layout: default
+```
+* In the frontmatter, under the footer text, add ```CHANGELOG. ``` after the date. _Leave it in all capital letters and do not translate it._<br>
+```<p><strong>Date:</strong> Updated 6 January 2021. CHANGELOG.</p>```
+
 ## 6 Jan 2021
-* Change "Web Content Accessibility Guidelines (WCAG) {#wcag}" to:
+* Change "### Web Content Accessibility Guidelines (WCAG) {#wcag}" to:
 ```
-Web Content Accessibility Guidelines (WCAG) 2 {#wcag2}
+### Web Content Accessibility Guidelines (WCAG) 2 {#wcag2}
 ```
-* Change "WCAG info" to:
+* Change "WCAG info:" to:
 ```
-WCAG 2 info
+WCAG 2 info:
 ```
-* Under "How to Meet WCAG 2 (Quick Reference)", add:
+* Around ```- [WCAG 2.0 Standard](https://www.w3.org/TR/WCAG20/)```add one link before and two links after:
 ```
-[[WCAG 2 Translations]](/standards-guidelines/wcag/translations/)
+        - [[WCAG 2 Translations]](/standards-guidelines/wcag/translations/)
+        - [WCAG 2.0 Standard](https://www.w3.org/TR/WCAG20/)
+        - [WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/), [[What’s New in WCAG 2.1]](/standards-guidelines/wcag/new-in-21/)
+        - [[What's New in WCAG 2.2 Working Draft]](/standards-guidelines/wcag/new-in-22/)
 ```
-* Change "[WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/)" to:
+
+* Before “## Technical Specifications”, add:
 ```
-[WCAG 2.1 Standard](https://www.w3.org/TR/WCAG21/), [[What’s New in WCAG 2.1]](/standards-guidelines/wcag/new-in-21/)
-```
-and add:
-```
-[[What's New in WCAG 2.2 Working Draft]](/standards-guidelines/wcag/new-in-22/)
-```
-* Under Authoring Tool Accessibility Guidelines (ATAG) {#atag} section, add:
-```
-W3C Accessibility Guidelines (WCAG) 3 Working Draft {#wcag3}
-```
-```
-WCAG 3 is an early draft that is intended to become a W3C Standard. WCAG 3 applies to web content, apps, tools, publishing, and emerging technologies on the web.
-```
-```
+        ### W3C Accessibility Guidelines (WCAG) 3 Working Draft {#wcag3}
+        WCAG 3 is an early draft that is intended to become a W3C Standard. WCAG 3 applies to web content, apps, tools, publishing, and emerging technologies on the web.
 WCAG 3 info:
-[[WCAG 3 Introduction]](/standards-guidelines/wcag/wcag3-intro/)
+        - [[WCAG 3 Introduction]](/standards-guidelines/wcag/wcag3-intro/)
 ```
 
 ## 11 Sep 2019
-* In [Pronunciation](/standards-guidelines/#pronunciation), text changed to:
+* Before “## Other Areas of W3C WAI work”, add:
 ```
+### Pronunciation
 [[Pronunciation Overview]](/pronunciation/) &mdash; Pronunciation is about screen readers and other text-to-speech (TTS) synthesis pronouncing content properly.
 ```
 
 ## 17 Jul 2019
-* In [Additional Information](/standards-guidelines/#moreinfo), link after [List of all W3C accessibility-related Standards ("W3C Recommendations") and Working Group Notes] was changed from https://www.w3.org/TR/#tr_Accessibility__All_ to: 
+* Under “## Additional Information {#moreinfo}”, in first item, change URI link to ``` https://www.w3.org/TR/?tag=accessibility```:
 ```
-https://www.w3.org/TR/?tag=accessibility
+        - [List of all W3C accessibility-related Standards ("W3C Recommendations") and Working Group Notes](https://www.w3.org/TR/?tag=accessibility)
 ```


### PR DESCRIPTION
Hi Tolu @bentocube 

I suggest a few changes:
* I added May 2021 changelog additions.
* I think the new WCAG 3 stuff is before “## Technical Specifications” (not after Authoring Tool Accessibility Guidelines (ATAG) {#atag}).

I tried this approach to try to make it easier to update translations:
* First, *where* the change is
* Then what the change is
* Then on a new line, the exact markup they can copy-paste

What do you think?

Do you want to take another pass at the mobile changelog with that approach? https://github.com/w3c/wai-mobile/pull/37 (also looks like some things missing in the preview?  https://deploy-preview-37--wai-mobile.netlify.app/standards-guidelines/mobile/changelog/ (probably need to figure out next point for that, too.))

<hr>

What I didn't figure out was how to get the copy-paste stuff not to be processed as markup! I tried ::nomarkup and code and pre and all sorts of stuff (https://github.com/w3c/wai-std-gl-overview/pull/44/commits)

For now, I used 8 spaces before (per https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks )
However, that doesn't make good copy-paste :-(

So if you figure out a solution for that, great!!!